### PR TITLE
[CosmosDB] Add minimal TLS version as a parameter for create/update operations

### DIFF
--- a/src/CosmosDB/CosmosDB.Test/ScenarioTests/AccountTests.ps1
+++ b/src/CosmosDB/CosmosDB.Test/ScenarioTests/AccountTests.ps1
@@ -32,8 +32,8 @@ function Test-AccountRelatedCmdlets
   $publicNetworkAccess = "Enabled"
   $networkAclBypass = "AzureServices"
   $networkAclBypassResourceId = @("/subscriptions/subId/resourcegroups/rgName/providers/Microsoft.Synapse/workspaces/workspaceName")
-
-  $cosmosDBAccount = New-AzCosmosDBAccount -ResourceGroupName $rgName -Name $cosmosDBAccountName -DefaultConsistencyLevel "BoundedStaleness" -MaxStalenessIntervalInSeconds 10  -MaxStalenessPrefix 20 -Location $location -IpRule $IpRule -Tag $tags -EnableVirtualNetwork  -EnableMultipleWriteLocations  -EnableAutomaticFailover -ApiKind "MongoDB" -PublicNetworkAccess $publicNetworkAccess -EnableFreeTier 0 -EnableAnalyticalStorage 0 -ServerVersion "3.2" -NetworkAclBypass $NetworkAclBypass -BackupRetentionIntervalInHours 16 -BackupIntervalInMinutes 480 -EnableBurstCapacity 1
+  
+  $cosmosDBAccount = New-AzCosmosDBAccount -ResourceGroupName $rgName -Name $cosmosDBAccountName -DefaultConsistencyLevel "BoundedStaleness" -MaxStalenessIntervalInSeconds 10  -MaxStalenessPrefix 20 -Location $location -IpRule $IpRule -Tag $tags -EnableVirtualNetwork  -EnableMultipleWriteLocations  -EnableAutomaticFailover -ApiKind "MongoDB" -PublicNetworkAccess $publicNetworkAccess -EnableFreeTier 0 -EnableAnalyticalStorage 0 -ServerVersion "3.2" -NetworkAclBypass $NetworkAclBypass -BackupRetentionIntervalInHours 16 -BackupIntervalInMinutes 480 -EnableBurstCapacity 1 -MinimalTlsVersion "Tls11"
   
   Assert-AreEqual $cosmosDBAccountName $cosmosDBAccount.Name
   Assert-AreEqual "BoundedStaleness" $cosmosDBAccount.ConsistencyPolicy.DefaultConsistencyLevel
@@ -51,6 +51,7 @@ function Test-AccountRelatedCmdlets
   Assert-AreEqual $cosmosDBAccount.BackupPolicy.BackupIntervalInMinutes 480
   Assert-AreEqual $cosmosDBAccount.BackupPolicy.BackupRetentionIntervalInHours 16
   Assert-AreEqual $cosmosDBAccount.EnableBurstCapacity 1
+  Assert-AreEqual $cosmosDBAccount.MinimalTlsVersion "Tls11" 
 
   # create an existing database
   Try {
@@ -60,7 +61,7 @@ function Test-AccountRelatedCmdlets
     Assert-AreEqual $_.Exception.Message ("Resource with Name " + $cosmosDBAccountName + " already exists.")
   }
 
-  $updatedCosmosDBAccount = Update-AzCosmosDBAccount -ResourceGroupName $rgName -Name $cosmosDBAccountName -DefaultConsistencyLevel "BoundedStaleness" -MaxStalenessIntervalInSeconds 10  -MaxStalenessPrefix 20 -IpRule $IpRule -Tag $tags -EnableVirtualNetwork 1 -EnableAutomaticFailover 1 -PublicNetworkAccess $publicNetworkAccess -NetworkAclBypassResourceId $networkAclBypassResourceId -EnablePartitionMerge 0 -EnableBurstCapacity 0
+  $updatedCosmosDBAccount = Update-AzCosmosDBAccount -ResourceGroupName $rgName -Name $cosmosDBAccountName -DefaultConsistencyLevel "BoundedStaleness" -MaxStalenessIntervalInSeconds 10  -MaxStalenessPrefix 20 -IpRule $IpRule -Tag $tags -EnableVirtualNetwork 1 -EnableAutomaticFailover 1 -PublicNetworkAccess $publicNetworkAccess -NetworkAclBypassResourceId $networkAclBypassResourceId -EnablePartitionMerge 0 -EnableBurstCapacity 0 -MinimalTlsVersion "Tls12"
 
   Assert-AreEqual $cosmosDBAccountName $updatedCosmosDBAccount.Name
   Assert-AreEqual "BoundedStaleness" $updatedCosmosDBAccount.ConsistencyPolicy.DefaultConsistencyLevel
@@ -75,6 +76,7 @@ function Test-AccountRelatedCmdlets
   Assert-AreEqual $updatedCosmosDBAccount.BackupPolicy.BackupRetentionIntervalInHours 16
   Assert-AreEqual $updatedCosmosDBAccount.EnablePartitionMerge 0
   Assert-AreEqual $updatedCosmosDBAccount.EnableBurstCapacity 0
+  Assert-AreEqual $updatedCosmosDBAccount.MinimalTlsVersion "Tls12"
 
   $updatedCosmosDBAccount = Update-AzCosmosDBAccount -ResourceGroupName $rgName -Name $cosmosDBAccountName -EnableBurstCapacity 1
   Assert-AreEqual $updatedCosmosDBAccount.EnableBurstCapacity 1

--- a/src/CosmosDB/CosmosDB/CosmosDBAccount/NewAzCosmosDBAccount.cs
+++ b/src/CosmosDB/CosmosDB/CosmosDBAccount/NewAzCosmosDBAccount.cs
@@ -60,6 +60,10 @@ namespace Microsoft.Azure.Commands.CosmosDB
         [Parameter(Mandatory = false, HelpMessage = Constants.LocationObjectHelpMessage)]
         [ValidateNotNullOrEmpty]
         public PSLocation[] LocationObject { get; set; }
+        
+        [Parameter(Mandatory = false, HelpMessage = Constants.MinimalTlsVersionHelpMessage)]
+        [PSArgumentCompleter(SDKModel.MinimalTlsVersion.Tls, SDKModel.MinimalTlsVersion.Tls11, SDKModel.MinimalTlsVersion.Tls12)]
+        public string MinimalTlsVersion { get; set; }
 
         // As of 03082022, using this list only for Mongo Accounts >= 3.6
         [Parameter(Mandatory = false, HelpMessage = Constants.LocationHelpMessage)]
@@ -171,6 +175,7 @@ namespace Microsoft.Azure.Commands.CosmosDB
             Collection<string> networkAclBypassResourceId = NetworkAclBypassResourceId != null ? new Collection<string>(NetworkAclBypassResourceId) : new Collection<string>();
             databaseAccountCreateUpdateParameters.NetworkAclBypassResourceIds = networkAclBypassResourceId;
             databaseAccountCreateUpdateParameters.EnableBurstCapacity = EnableBurstCapacity;
+            databaseAccountCreateUpdateParameters.MinimalTlsVersion = MinimalTlsVersion;
 
             if (IpRule != null && IpRule.Length > 0)
             {

--- a/src/CosmosDB/CosmosDB/CosmosDBAccount/NewOrUpdateAzCosmosDBAccount.cs
+++ b/src/CosmosDB/CosmosDB/CosmosDBAccount/NewOrUpdateAzCosmosDBAccount.cs
@@ -113,6 +113,10 @@ namespace Microsoft.Azure.Commands.CosmosDB
         [PSArgumentCompleter(SDKModel.AnalyticalStorageSchemaType.WellDefined, SDKModel.AnalyticalStorageSchemaType.FullFidelity)]
         public string AnalyticalStorageSchemaType { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = Constants.MinimalTlsVersionHelpMessage)]
+        [PSArgumentCompleter(SDKModel.MinimalTlsVersion.Tls, SDKModel.MinimalTlsVersion.Tls11, SDKModel.MinimalTlsVersion.Tls12)]
+        public string MinimalTlsVersion { get; set; }
+
         public ConsistencyPolicy PopoulateConsistencyPolicy(string DefaultConsistencyLevel, int? MaxStalenessIntervalInSeconds, int? MaxStalenessPrefix)
         {
             ConsistencyPolicy consistencyPolicy = new ConsistencyPolicy();

--- a/src/CosmosDB/CosmosDB/CosmosDBAccount/UpdateAzCosmosDBAccount.cs
+++ b/src/CosmosDB/CosmosDB/CosmosDBAccount/UpdateAzCosmosDBAccount.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Azure.Commands.CosmosDB
         [Parameter(Mandatory = false, HelpMessage = Constants.DisableKeyBasedMetadataWriteAccessHelpMessage)]
         public bool? DisableKeyBasedMetadataWriteAccess { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = Constants.MinimalTlsVersionHelpMessage)]
+        public string MinimalTlsVersion { get; set; }
+
         public override void ExecuteCmdlet()
         {
             if (!ParameterSetName.Equals(NameParameterSet, StringComparison.Ordinal))
@@ -228,6 +231,11 @@ namespace Microsoft.Azure.Commands.CosmosDB
                         }
                     };
                 }
+            }
+
+            if(!string.IsNullOrEmpty(MinimalTlsVersion))
+            {
+                databaseAccountUpdateParameters.MinimalTlsVersion = MinimalTlsVersion;
             }
             
             // Update analytical storage schema type.

--- a/src/CosmosDB/CosmosDB/Helpers/Constants.cs
+++ b/src/CosmosDB/CosmosDB/Helpers/Constants.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Commands.CosmosDB.Helpers
         public const string DatabaseResourceIdHelpMessage = "ResourceId of the database.";
         public const string AnalyticalStorageSchemaTypeHelpMessage = "The schema type for analytical storage. Valid values include: 'WellDefined' and 'FullFidelity'.";
         public const string EnablePartitionMergeHelpMessage = "Enables partition merge feature on the Cosmos DB database account. Accepted values: false, true";
+        public const string MinimalTlsVersionHelpMessage = "Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2. Possible values include: 'Tls', 'Tls11', 'Tls12'.";
 
         //Restore specific help messages
         public const string IsRestoreRequestHelpMessage = "Indicates that the new Cosmos DB account request is a restore request.";

--- a/src/CosmosDB/CosmosDB/Models/DatabaseAccount/PSDatabaseAccountGetResults.cs
+++ b/src/CosmosDB/CosmosDB/Models/DatabaseAccount/PSDatabaseAccountGetResults.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Azure.Commands.CosmosDB.Models
             CreateMode = databaseAccountGetResults.CreateMode;
             AnalyticalStorageConfiguration = new PSAnalyticalStorageConfiguration(databaseAccountGetResults.AnalyticalStorageConfiguration);
             EnablePartitionMerge = databaseAccountGetResults.EnablePartitionMerge;
+            MinimalTlsVersion = databaseAccountGetResults.MinimalTlsVersion;
         }
 
         //
@@ -234,5 +235,10 @@ namespace Microsoft.Azure.Commands.CosmosDB.Models
         // Summary:
         //     Gets or sets the AnalyticalStorageConfiguration of the CosmosDB Account
         public PSAnalyticalStorageConfiguration AnalyticalStorageConfiguration { get; set; }
+        //
+        //
+        // Summary:
+        //     Gets or sets the MinimalTlsVersion of the CosmosDB Account
+        public string MinimalTlsVersion { get; set; }
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This change allows for customers to specify the minimal TLS version while creating or updating an account. The accepted values for the minimal Tls version are 'Tls', 'Tls11', and 'Tls12', which correspond to the TLS versions 1.0, 1.1, and 1.2. If no TLS version is specified, the default Tls version is 1.0, except for Cassandra and Mongo API's, which only work with Tls version 1.2

## Checklist

- [ ] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** select appropriate branch. Cmdlets from Autorest.PowerShell should go to [`generation`](https://github.com/Azure/azure-powershell/tree/generation) branch. 
* **SHOULD** make the title of PR clear and informative, and in the present imperative tense. 
* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. Add changelog in description section if PR goes into [`generation`](https://github.com/Azure/azure-powershell/tree/generation) branch.
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** have approved design review for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) ([_Microsoft internal only_](../blob/main/CONTRIBUTING.md#onboarding)) with following situations
    * Create new module from scratch
    * Create new resource types which are not easy to conform to [Azure PowerShell Design Guidelines](../blob/main/documentation/development-docs/design-guidelines)
    * Create new resource type which name doesn't use module name as prefix
    * Have design question before implementation
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** introduce [breaking changes](../blob/main/documentation/breaking-changes/breaking-changes-definition.md) in Az minor release except preview version.
* **SHOULD NOT** adjust version of module manually in pull request
